### PR TITLE
fix: render the background themed elements based grid layout so its consistent and uniformly distributed across screen

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -5,8 +5,8 @@
   box-sizing: border-box;
 
   .subtext {
-    font-size: 0.8rem;
-    font-weight: 500;
+    font-size: 1rem;
+    font-weight: 600;
     color: #212529;
   }
   .flex {
@@ -107,6 +107,8 @@
   .decrypt-text {
     font-size: 1.25rem;
     font-weight: 500;
+    min-height: 5rem;
+
     &.latin {
       color: #74b816;
     }
@@ -119,7 +121,7 @@
     padding: 12px 10px;
     border: 1px solid #ddd;
     border-radius: 4px;
-    font-size: 1rem;
+    font-size: 1.25rem;
   }
 }
 

--- a/src/DynamicBackground.tsx
+++ b/src/DynamicBackground.tsx
@@ -107,7 +107,6 @@ const calculateGridDimensions = (
   const aspectRatio = screenWidth / screenHeight;
   const cols = Math.ceil(Math.sqrt(aspectRatio) * MULTIPLIER);
   const rows = Math.ceil(cols / aspectRatio);
-  console.log(rows, cols, aspectRatio, screenHeight, screenWidth);
   return { cols, rows };
 };
 
@@ -119,7 +118,6 @@ const { rows, cols } = calculateGridDimensions(
 
 const gridCellWidth = Math.floor(window.innerWidth / cols);
 const gridCellHeight = Math.floor(window.innerHeight / rows);
-console.log(gridCellHeight, gridCellWidth);
 const DynamicBackground = React.memo(
   ({ theme = "emoji" }: { theme: keyof typeof themes }) => {
     const [elements, setElements] = useState<Array<Element>>([]);

--- a/src/DynamicBackground.tsx
+++ b/src/DynamicBackground.tsx
@@ -98,6 +98,28 @@ const getRandomColor = () => {
   return color;
 };
 
+const calculateGridDimensions = (
+  eleCount: number,
+  screenWidth: number,
+  screenHeight: number,
+) => {
+  const MULTIPLIER = 10;
+  const aspectRatio = screenWidth / screenHeight;
+  const cols = Math.ceil(Math.sqrt(aspectRatio) * MULTIPLIER);
+  const rows = Math.ceil(cols / aspectRatio);
+  console.log(rows, cols, aspectRatio, screenHeight, screenWidth);
+  return { cols, rows };
+};
+
+const { rows, cols } = calculateGridDimensions(
+  100,
+  window.innerWidth,
+  window.innerHeight,
+);
+
+const gridCellWidth = Math.floor(window.innerWidth / cols);
+const gridCellHeight = Math.floor(window.innerHeight / rows);
+console.log(gridCellHeight, gridCellWidth);
 const DynamicBackground = React.memo(
   ({ theme = "emoji" }: { theme: keyof typeof themes }) => {
     const [elements, setElements] = useState<Array<Element>>([]);
@@ -105,38 +127,34 @@ const DynamicBackground = React.memo(
       Array<{ x: number; y: number; size: number }>
     >([]);
 
-    const createElement = useCallback((content: Array<string>) => {
-      const size = randomInRange(20, 80); // Random size for elements
-      let newPos;
-
-      newPos = {
-        x: randomInRange(0, window.innerWidth - size),
-        y: randomInRange(0, window.innerHeight - size),
-      };
-
-      placedElements.current.push({ x: newPos.x, y: newPos.y, size });
-
-      // Return the element object
-      return {
-        content: content[randomInRange(0, content.length - 1)],
-        size,
-        x: newPos.x,
-        y: newPos.y,
-        color: getRandomColor(),
-      };
-    }, []);
-
     useEffect(() => {
       placedElements.current = [];
 
       const content = themes[theme] || themes.emoji;
       const elementsArray: Array<Element> = [];
 
-      for (let i = 0; i < 50; i++) {
-        elementsArray.push(createElement(content));
+      for (let i = 0; i < cols * rows; i++) {
+        const minwidth = Math.min(20, gridCellWidth);
+        const maxWidth = Math.min(80, gridCellWidth);
+        const size = randomInRange(minwidth, maxWidth); // Random size for elements
+        const col = i % cols;
+        const row = Math.floor(i / cols);
+
+        // Calculate position for each emoji
+        const x = col * gridCellWidth;
+        const y = row * gridCellHeight;
+
+        placedElements.current.push({ x, y, size });
+        elementsArray.push({
+          content: content[randomInRange(0, content.length - 1)],
+          size,
+          x,
+          y,
+          color: getRandomColor(),
+        });
       }
       setElements(elementsArray);
-    }, [createElement, theme]);
+    }, [theme]);
 
     return (
       <div className="dynamic-bg">

--- a/src/Footer.scss
+++ b/src/Footer.scss
@@ -1,11 +1,11 @@
 .footer {
   bottom: 0;
   position: absolute;
-  width: 100%;
+  width: 95%;
   text-align: center;
   margin: 20px;
-  font-size: 0.8rem;
-  font-weight: 500;
+  font-size: 1rem;
+  font-weight: 600;
   color: #212529;
 
   a {


### PR DESCRIPTION
To ensure the background elements don't overlap, I am rendering it based on a grid layout using the screen aspect ratio so it's uniformly distributed across screen dimensions.
I am calculating the rows and columns based on aspect ratio and rendering the elements sequentially to ensure there is no overlap  and screen is fully filled as well.

Before
<img width="1288" alt="Screenshot 2024-10-17 at 12 43 29 AM" src="https://github.com/user-attachments/assets/a55634d2-80e0-41b8-a6de-b7c0868fc25d">

Now
<img width="1299" alt="Screenshot 2024-10-17 at 12 43 47 AM" src="https://github.com/user-attachments/assets/b0a3c5c8-18a1-4d52-b89d-ac88fb2e86c1">
